### PR TITLE
LexMintable layer to LexNFT

### DIFF
--- a/contracts/conditions/LexMintable.sol
+++ b/contracts/conditions/LexMintable.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+/// @notice This must be layered on top of both LexNFT and LexOwnable. Extends LexNFT to allow multiple mints by owner.
+
+import './LexNFT.sol';
+import './LexOwnable.sol';
+
+contract LexMintable is LexOwnable, LexNFT {
+
+    uint counter;
+
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint256 tokenId,
+        string memory _tokenURI,
+        address owner
+    ) LexNFT(_name, _symbol, tokenId, _tokenURI, owner)
+       {
+        counter = tokenId + 1;
+    }
+    function mint(address to, string memory _tokenURI) public onlyOwner {
+        _mint(to, counter, _tokenURI);
+    }
+
+    function burn(uint tokenId) public onlyOwner {
+        _burn(tokenId);
+    }
+
+}


### PR DESCRIPTION
experimental layer to LexNFT, which would allow owner to mint multiple tokens. requires LexNFT and LexOwnable. is conditions the right place for this? or would it be better to create an alternative to LexNFT that allows minting?

(yet another option is to modify LexNFT to allow minting, but create a condition that would override that capability)